### PR TITLE
Allow container to stop gracefully

### DIFF
--- a/vantage6/cli/node.py
+++ b/vantage6/cli/node.py
@@ -444,7 +444,9 @@ def cli_node_stop(name, system_folders, all_nodes):
 
         if name in running_node_names:
             container = client.containers.get(name)
-            container.kill()
+            # Stop the container. Using stop() gives the container 10s to exit
+            # itself, if not then it will be killed
+            container.stop()
             info(f"Stopped the {Fore.GREEN}{name}{Style.RESET_ALL} Node.")
         else:
             error(f"{Fore.RED}{name}{Style.RESET_ALL} is not running?")


### PR DESCRIPTION
This solves the issue IKNL/vantage-server#42 that the node status in the database was sometimes incorrect: while exiting we now properly disconnect the socket IO which also updates the node status.

This pull request goes hand in hand with [this pull request in vantage-node](https://github.com/IKNL/vantage6-node/pull/36). Both are required to solve the issue.