### PR TITLE
Extended `vnode/vserver new` with VPN fields

### DIFF
--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -12,6 +12,7 @@ from vantage6.cli.configuration_wizard import (
 
 module_path = "vantage6.cli.configuration_wizard"
 
+
 class WizardTest(unittest.TestCase):
 
     @staticmethod
@@ -33,12 +34,12 @@ class WizardTest(unittest.TestCase):
 
         with patch(f"{module_path}.q") as q:
             q.prompt.side_effect = self.prompts
-            q.confirm.return_value.ask.side_effect = [True, False]
+            q.confirm.return_value.ask.side_effect = [True, False, True]
             dirs = MagicMock(data="/")
             config = node_configuration_questionaire(dirs, "iknl")
 
         keys = ["api_key", "server_url", "port", "api_path", "task_dir",
-                "databases", "logging", "encryption"]
+                "databases", "logging", "encryption", "vpn_subnet"]
         for key in keys:
             self.assertIn(key, config)
 
@@ -46,12 +47,13 @@ class WizardTest(unittest.TestCase):
 
         with patch(f"{module_path}.q") as q:
             q.prompt.side_effect = self.prompts
-            q.confirm.return_value.ask.side_effect = [True]
+            q.confirm.return_value.ask.side_effect = [True, True]
 
             config = server_configuration_questionaire("", "vantage6")
 
             keys = ["description", "ip", "port", "api_path", "uri",
-                    "allow_drop_all", "jwt_secret_key", "logging"]
+                    "allow_drop_all", "jwt_secret_key", "logging",
+                    "vpn_server"]
 
             for key in keys:
                 self.assertIn(key, config)

--- a/vantage6/cli/configuration_wizard.py
+++ b/vantage6/cli/configuration_wizard.py
@@ -80,7 +80,7 @@ def node_configuration_questionaire(dirs, instance_name):
     if is_add_vpn:
         config['vpn_subnet'] = q.text(
             message="Subnet of the VPN server you want to connect to:",
-            default='1.2.3.4/16'
+            default='10.76.0.0/16'
         ).ask()
 
     config["logging"] = {

--- a/vantage6/cli/configuration_wizard.py
+++ b/vantage6/cli/configuration_wizard.py
@@ -148,6 +148,44 @@ def server_configuration_questionaire(dirs, instance_name):
                    choices=["DEBUG", "INFO", "WARNING", "ERROR",
                             "CRITICAL", "NOTSET"]).ask()
 
+    is_add_vpn = q.confirm(
+        "Do you want to add a VPN server?", default=False).ask()
+    if is_add_vpn:
+        vpn_config = q.prompt([
+            {
+                "type": "text",
+                "name": "url",
+                "message": "VPN server URL:",
+            },
+            {
+                "type": "text",
+                "name": "portal_username",
+                "message": "VPN portal username:",
+            },
+            {
+                "type": "password",
+                "name": "portal_userpass",
+                "message": "VPN portal password:",
+            },
+            {
+                "type": "text",
+                "name": "client_id",
+                "message": "VPN client username:",
+            },
+            {
+                "type": "password",
+                "name": "client_secret",
+                "message": "VPN client password:",
+            },
+            {
+                "type": "text",
+                "name": "redirect_url",
+                "message": "Redirect url (should be local address of server)",
+                "default": "http://localhost"
+            }
+        ])
+        config['vpn_server'] = vpn_config
+
     config["logging"] = {
         "level": res,
         "file": f"{instance_name}.log",

--- a/vantage6/cli/configuration_wizard.py
+++ b/vantage6/cli/configuration_wizard.py
@@ -75,6 +75,14 @@ def node_configuration_questionaire(dirs, instance_name):
                    choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL",
                             "NOTSET"]).ask()
 
+    is_add_vpn = q.confirm(
+        "Do you want to connect to a VPN server?", default=False).ask()
+    if is_add_vpn:
+        config['vpn_subnet'] = q.text(
+            message="Subnet of the VPN server you want to connect to:",
+            default='1.2.3.4/16'
+        ).ask()
+
     config["logging"] = {
         "level": res,
         "file": f"{instance_name}.log",

--- a/vantage6/cli/server.py
+++ b/vantage6/cli/server.py
@@ -314,7 +314,6 @@ def cli_server_files(ctx):
               default=DEFAULT_SERVER_SYSTEM_FOLDERS)
 def cli_server_new(name, environment, system_folders):
     """Create new configuration."""
-
     if not name:
         name = q.text("Please enter a configuration-name:").ask()
         name_new = name.replace(" ", "-")


### PR DESCRIPTION
Fix IKNL/vantage6-main#18 
Note that there is an additional PR in the server repo to fix this for `vserver-local`. No changes were necessary for `vnode-local` in the node repo.